### PR TITLE
remove_EMSCRIPTEN

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -318,9 +318,6 @@ protected:
                     MacroBuilder &Builder) const override {
     // A macro for the platform.
     Builder.defineMacro("__EMSCRIPTEN__");
-    // Earlier versions of Emscripten defined this, so we continue to define it
-    // for compatibility, for now. Users should ideally prefer __EMSCRIPTEN__.
-    Builder.defineMacro("EMSCRIPTEN");
     // A common platform macro.
     if (Opts.POSIXThreads)
       Builder.defineMacro("_REENTRANT");


### PR DESCRIPTION
Remove deprecated `EMSCRIPTEN` define.

This is somewhat annoying to remove conditional to Emscripten strict mode flag or env. var, so I propose we merge this only way later after the emscripten_strict PR has landed for a version or two.