### PR TITLE
Support use of external clang sources in emscripten-version number generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,9 @@ endif()
 # Unlike PACKAGE_VERSION, CLANG_VERSION does not include LLVM_VERSION_SUFFIX.
 set(CLANG_VERSION "${CLANG_VERSION_MAJOR}.${CLANG_VERSION_MINOR}.${CLANG_VERSION_PATCHLEVEL}")
 message(STATUS "Clang version: ${CLANG_VERSION}")
+if(DEFINED LLVM_EXTERNAL_CLANG_SOURCE_DIR)
+  add_definitions(-DLLVM_EXTERNAL_CLANG_SOURCE_DIR)
+endif()
 
 # Configure the Version.inc file.
 configure_file(

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -135,7 +135,7 @@ std::string getClangToolFullVersion(StringRef ToolName) {
 
   // XXX EMSCRIPTEN: show our versions
   // If the clang source is separate from LLVM, don't try to find it.
-  // Just asume the version numbers match
+  // Just assume the version numbers match
   OS <<  " (emscripten "
 #ifdef LLVM_EXTERNAL_CLANG_SOURCE_DIR
   #include "../../emscripten-version.txt"

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -134,10 +134,18 @@ std::string getClangToolFullVersion(StringRef ToolName) {
 #endif
 
   // XXX EMSCRIPTEN: show our versions
+  // If the clang source is separate from LLVM, don't try to find it.
+  // Just asume the version numbers match
   OS <<  " (emscripten "
+#ifdef LLVM_EXTERNAL_CLANG_SOURCE_DIR
+  #include "../../emscripten-version.txt"
+      " : "
+  #include "../../emscripten-version.txt"
+#else
 #include "../../../../emscripten-version.txt"
          " : "
 #include "../../../../tools/clang/emscripten-version.txt"
+#endif
          ")";
 
   return OS.str();


### PR DESCRIPTION
Using clang sources external to LLVM (i.e. not in the tools/clang subdir)
breaks the includes used by fastcomp clang to print the version numbers.
This patch fixes the paths, but we also want for the time being not to break
any existing build scripts (such as emslave). So instead of just changing
the path, inject a define into the build to conditionally select one.

I didn't try to make it support separate versions for LLVM and clang
(since we dont actually use that currently) but I did keep the same
format.